### PR TITLE
fixed: player duration error Infinity:NaN

### DIFF
--- a/src/hooks/usePlayerTime.ts
+++ b/src/hooks/usePlayerTime.ts
@@ -1,23 +1,20 @@
 import { useEffect, useState } from "react";
 import usePlayer from "./usePlayer";
+import { useRecoilValue } from "recoil";
+import { PlayerDurationState } from "@/state/player";
 
 export default function usePlayerTime() {
-    const [player] = usePlayer();
     const [currentTime, setCurrentTime] = useState(0);
-    const [duration, setDuration] = useState(0);
+    const duration = useRecoilValue(PlayerDurationState);
+    const [player] = usePlayer();
     useEffect(() => {
         const onTimeUpdate = () => {
             setCurrentTime(player.currentTime);
         };
-        const onDurationChange = () => {
-            setDuration(player.duration);
-        };
         player.addEventListener("timeupdate", onTimeUpdate);
-        player.addEventListener("durationchange", onDurationChange);
         return () => {
             player.removeEventListener("timeupdate", onTimeUpdate);
-            player.removeEventListener("durationchange", onDurationChange);
         };
-    }, [player]);
+    }, [player, duration]);
     return [currentTime, duration] as const;
 }

--- a/src/state/player.ts
+++ b/src/state/player.ts
@@ -19,3 +19,8 @@ export const NowPlayingInfoState = atom<Partial<PlayQueueItem>>({
     key: "NowPlayingInfoState",
     default: {},
 });
+
+export const PlayerDurationState = atom({
+    key: "PlayerDurationState",
+    default: 0,
+});


### PR DESCRIPTION
为了修复这个 bug，添加了一个新的 State，考量如下：

原先 PlayerState 就是一个独立的 State，但是由于 HTTPAudioElement 中的 duration 在**流媒体播放时总是 Infinity**（除了最后三秒外）

这个 duration 应该和 PlayerState 有同等地位（绑在一起了），但是考虑到原有的代码可能需要直接调用它，所以并没有将其直接并入 PlayerState，而是另外加了个 PlayerDurationState

当然最主要原因是，直接弄一个回调函数给 usePlayer 是没有用的，因为这个 duration 只在调用 play() 的时候更新，但是此时 usePlayerTime 并不会执行 play()，想不到其他办法了

这个问题解决后，anniw 的进度条也能拖动了